### PR TITLE
Added option to enable dialog for file name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "tempfile.newfile",
+        "command": "tempfile.newfile.default",
         "title": "New tempfile"
+      },
+      {
+        "command": "tempfile.newfile.alt",
+        "title": "New tmpfile"
       }
     ],
     "keybindings": [
@@ -50,6 +54,12 @@
           "default": false,
           "description": "If True, append initialContent to the existing file.",
           "order": 2
+        },
+        "tempfile.ending": {
+          "type": "boolean",
+          "default": false,
+          "description": "If True, will ask which file ending you want.",
+          "order": 3
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,12 +39,22 @@ const newfile = async () => {
   }
 
   if (config.get<boolean>("ending") ?? false) {
-    pathTemplate = pathTemplate.replace(/(.*)\.[^.]+$/, "$1"); // remove possible set file endings
+    let ending = pathTemplate;
+    for (let i = pathTemplate.length - 1; i >= 0; i--) {
+      if (['.', '/'].includes(pathTemplate[i])) {
+        ending = pathTemplate.substring(i + 1);
+        pathTemplate = pathTemplate.substring(0, i);
+        break;
+      }
+    }
+    if (pathTemplate === ending) pathTemplate = '';
     const userInput = await vscode.window.showInputBox({
       prompt: 'What file ending?',
     });
-    if (!userInput) {return;}
-    const ending = userInput.trim().replace(/^\./, '');
+    if (userInput) {
+      const strippedUserInput = userInput.trim().replace(/^\./, '');
+      if (strippedUserInput !== '') ending = strippedUserInput;
+    }
     pathTemplate += '.' + (ending !== '' ? ending : 'file');
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,12 +39,13 @@ const newfile = async () => {
   }
 
   if (config.get<boolean>("ending") ?? false) {
-    pathTemplate = pathTemplate.replace(/(?<=\/[^\/]*\.)[^\/]*$/, ''); // remove possible set file endings
+    pathTemplate = pathTemplate.replace(/(.*)\.[^.]+$/, "$1"); // remove possible set file endings
     const userInput = await vscode.window.showInputBox({
       prompt: 'What file ending?',
     });
     if (!userInput) {return;}
-    pathTemplate += (userInput.startsWith('.') ? '' : '.') + userInput;
+    const ending = userInput.trim().replace(/^\./, '');
+    pathTemplate += '.' + (ending !== '' ? ending : 'file');
   }
 
   const pathParameters = makePathParameters();


### PR DESCRIPTION
This pull request introduces two new features / improvements to the existing VS Code plugin:

1. Adds a new setting option to prompt the user for a file extension when creating a new temporary file.
2. Duplicates the 'new tempfile' command for easier access with a new label, 'new tmpfile'.